### PR TITLE
Update task entity and create task bundle

### DIFF
--- a/api/NOUVELLES_ENTITES_SOLUTION.md
+++ b/api/NOUVELLES_ENTITES_SOLUTION.md
@@ -1,0 +1,159 @@
+# Documentation des nouvelles modifications
+
+## Modifications apportées
+
+### 1. Ajout de la propriété `points` à l'entité Task
+
+**Localisation** : `api/src/entities/Task.ts`
+
+```typescript
+@Column({ type: 'int', default: 0 })
+@IsPositive()
+points: number;
+```
+
+**Justification** : Simple ajout d'une propriété entière pour gérer un système de points par tâche.
+
+### 2. Gestion des relations `concernedTasks` et `acknowledgedTasks`
+
+**Solution adoptée** : Création d'une nouvelle entité `UserTaskState`
+
+**Localisation** : `api/src/entities/UserTaskState.ts`
+
+#### Pourquoi cette approche ?
+
+Au lieu d'ajouter directement des relations Many-to-Many sur l'entité User, j'ai créé une entité intermédiaire `UserTaskState` pour les raisons suivantes :
+
+1. **Séparation des responsabilités** : Une entité dédiée pour gérer l'état des tâches par utilisateur
+2. **Évolutivité** : Facilite l'ajout de nouveaux états ou métadonnées
+3. **Performance** : Meilleure indexation et requêtes plus efficaces
+4. **Auditabilité** : Traçabilité des dates de modification (`acknowledgedAt`, `concernedAt`)
+5. **Intégrité des données** : Contrainte unique (`user`, `task`) pour éviter les doublons
+
+#### Structure de l'entité UserTaskState
+
+```typescript
+@Entity()
+@Unique(['user', 'task'])
+export class UserTaskState {
+  id: number;
+  user: User;                    // Référence vers l'utilisateur
+  task: Task;                    // Référence vers la tâche
+  isAcknowledged: boolean;       // Si l'utilisateur a vu la tâche
+  isConcerned: boolean;          // Si l'utilisateur se sent concerné
+  acknowledgedAt?: Date;         // Date de prise de connaissance
+  concernedAt?: Date;            // Date de marquage comme concerné
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+#### Relations ajoutées
+
+- **User** : Relation `OneToMany` vers `UserTaskState`
+- **Task** : Relation `OneToMany` vers `UserTaskState`
+
+#### Avantages de cette solution
+
+1. **Historique complet** : Possibilité de savoir quand un utilisateur a marqué une tâche
+2. **Flexibilité** : Ajout facile de nouveaux états (ex: `isPriority`, `isArchived`)
+3. **Performance** : Requêtes optimisées avec index sur (`user`, `task`)
+4. **Cohérence** : Évite la duplication des données
+5. **Maintenabilité** : Code plus propre et relations plus claires
+
+#### Utilisation
+
+```typescript
+// Récupérer les tâches que l'utilisateur a vues
+const acknowledgedTasks = await userTaskStateRepository.find({
+  where: { user: { id: userId }, isAcknowledged: true },
+  relations: ['task']
+});
+
+// Récupérer les tâches qui concernent l'utilisateur
+const concernedTasks = await userTaskStateRepository.find({
+  where: { user: { id: userId }, isConcerned: true },
+  relations: ['task']
+});
+
+// Marquer une tâche comme vue
+await userTaskStateRepository.save({
+  user: { id: userId },
+  task: { id: taskId },
+  isAcknowledged: true,
+  acknowledgedAt: new Date()
+});
+```
+
+### 3. Entité TaskBundle
+
+**Localisation** : `api/src/entities/TaskBundle.ts`
+
+#### Objectif
+
+Permettre l'enregistrement groupé de tâches avec des métadonnées communes.
+
+#### Structure
+
+```typescript
+@Entity()
+export class TaskBundle {
+  id: number;
+  label: string;                 // Nom du bundle
+  description?: string;          // Description optionnelle
+  tasks: Task[];                 // Tâches incluses dans le bundle
+  createdBy: User;               // Utilisateur créateur
+  group: Group;                  // Groupe auquel appartient le bundle
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+#### Avantages
+
+1. **Atomicité** : Possibilité d'enregistrer plusieurs tâches en une seule transaction
+2. **Organisation** : Regroupement logique de tâches liées
+3. **Traçabilité** : Suivi de qui a créé le bundle et dans quel groupe
+4. **Flexibilité** : Possibilité d'ajouter des métadonnées au niveau du bundle
+
+#### Utilisation
+
+```typescript
+// Créer un bundle avec plusieurs tâches
+const taskBundle = new TaskBundle();
+taskBundle.label = "Tâches de nettoyage";
+taskBundle.description = "Tâches hebdomadaires de maintenance";
+taskBundle.tasks = [task1, task2, task3];
+taskBundle.createdBy = user;
+taskBundle.group = group;
+
+await taskBundleRepository.save(taskBundle);
+```
+
+## Fichiers modifiés
+
+1. **api/src/entities/Task.ts** : Ajout de la propriété `points`
+2. **api/src/entities/User.ts** : Ajout de la relation `taskStates`
+3. **api/src/entities/UserTaskState.ts** : Nouvelle entité (créée)
+4. **api/src/entities/TaskBundle.ts** : Nouvelle entité (créée)
+5. **api/src/config/database.ts** : Ajout des nouvelles entités dans la configuration
+
+## Prochaines étapes recommandées
+
+1. **Créer les repositories** pour les nouvelles entités
+2. **Développer les routes API** pour gérer les nouvelles fonctionnalités
+3. **Créer les controllers** correspondants
+4. **Ajouter les validations** et middleware nécessaires
+5. **Écrire les tests** pour les nouvelles fonctionnalités
+6. **Mettre à jour la documentation API**
+
+## Base de données
+
+Les nouvelles tables créées automatiquement par TypeORM :
+- `user_task_state` : Pour gérer les états des tâches par utilisateur
+- `task_bundle` : Pour les bundles de tâches
+- `task_bundle_tasks_task` : Table de liaison Many-to-Many pour TaskBundle-Task
+
+## Migration
+
+En développement, les tables seront créées automatiquement grâce à `synchronize: true`. En production, il est recommandé de créer des migrations TypeORM pour ces nouvelles entités.

--- a/api/src/config/database.ts
+++ b/api/src/config/database.ts
@@ -4,6 +4,8 @@ import { Group } from '../entities/Group';
 import { Task } from '../entities/Task';
 import { Action } from '../entities/Action';
 import { Tag } from '../entities/Tag';
+import { UserTaskState } from '../entities/UserTaskState';
+import { TaskBundle } from '../entities/TaskBundle';
 import * as path from 'path';
 
 export const AppDataSource = new DataSource({
@@ -11,7 +13,7 @@ export const AppDataSource = new DataSource({
   database: process.env.DATABASE_PATH || './database.sqlite',
   synchronize: true, // En production, utiliser des migrations
   logging: process.env.NODE_ENV === 'development',
-  entities: [User, Group, Task, Action, Tag],
+  entities: [User, Group, Task, Action, Tag, UserTaskState, TaskBundle],
   migrations: [path.join(__dirname, '../migrations/**/*{.ts,.js}')],
   subscribers: [path.join(__dirname, '../subscribers/**/*{.ts,.js}')],
 });

--- a/api/src/entities/Task.ts
+++ b/api/src/entities/Task.ts
@@ -3,6 +3,7 @@ import { IsNotEmpty, IsPositive, IsUrl, IsOptional } from 'class-validator';
 import { Group } from './Group';
 import { Tag } from './Tag';
 import { Action } from './Action';
+import { UserTaskState } from './UserTaskState';
 
 export enum FrequencyUnit {
   JOUR = 'jour',
@@ -35,6 +36,10 @@ export class Task {
   })
   uniteFrequence: FrequencyUnit;
 
+  @Column({ type: 'int', default: 0 })
+  @IsPositive()
+  points: number;
+
   @ManyToOne(() => Group, group => group.tasks)
   group: Group;
 
@@ -43,6 +48,9 @@ export class Task {
 
   @OneToMany(() => Action, action => action.task)
   actions: Action[];
+
+  @OneToMany(() => UserTaskState, (userTaskState: UserTaskState) => userTaskState.task)
+  userStates: UserTaskState[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/api/src/entities/TaskBundle.ts
+++ b/api/src/entities/TaskBundle.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToMany, JoinTable, ManyToOne } from 'typeorm';
+import { IsNotEmpty } from 'class-validator';
+import { Task } from './Task';
+import { User } from './User';
+import { Group } from './Group';
+
+@Entity()
+export class TaskBundle {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @IsNotEmpty()
+  label: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @ManyToMany(() => Task)
+  @JoinTable()
+  tasks: Task[];
+
+  @ManyToOne(() => User)
+  createdBy: User;
+
+  @ManyToOne(() => Group)
+  group: Group;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/api/src/entities/User.ts
+++ b/api/src/entities/User.ts
@@ -3,6 +3,7 @@ import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 import * as bcrypt from 'bcryptjs';
 import { Group } from './Group';
 import { Action } from './Action';
+import { UserTaskState } from './UserTaskState';
 
 @Entity()
 export class User {
@@ -37,6 +38,9 @@ export class User {
 
   @OneToMany(() => Action, action => action.user)
   actions: Action[];
+
+  @OneToMany(() => UserTaskState, (userTaskState: UserTaskState) => userTaskState.user)
+  taskStates: UserTaskState[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/api/src/entities/UserTaskState.ts
+++ b/api/src/entities/UserTaskState.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, Unique } from 'typeorm';
+import { User } from './User';
+import { Task } from './Task';
+
+@Entity()
+@Unique(['user', 'task'])
+export class UserTaskState {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user: User) => user.taskStates)
+  user: User;
+
+  @ManyToOne(() => Task, (task: Task) => task.userStates)
+  task: Task;
+
+  @Column({ type: 'boolean', default: false })
+  isAcknowledged: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isConcerned: boolean;
+
+  @Column({ type: 'datetime', nullable: true })
+  acknowledgedAt?: Date;
+
+  @Column({ type: 'datetime', nullable: true })
+  concernedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds `points` to the `Task` entity, introduces `UserTaskState` for user-task relations, and creates `TaskBundle` for grouping tasks.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `UserTaskState` entity was introduced to manage user-specific task states (acknowledged, concerned) in a dedicated, flexible, and auditable manner. This approach offers better scalability, performance, and data integrity compared to adding direct Many-to-Many relations on the `User` entity.