### PR TITLE
Create action method in TaskRepository

### DIFF
--- a/TASK_ACTION_IMPLEMENTATION.md
+++ b/TASK_ACTION_IMPLEMENTATION.md
@@ -1,0 +1,72 @@
+# Implémentation de la création d'actions au clic sur TaskCard
+
+## Vue d'ensemble
+
+J'ai implémenté une nouvelle fonctionnalité permettant de créer une Action en cliquant sur une TaskCard. Cette implémentation respecte l'architecture existante et les règles métier définies côté API.
+
+## Modifications apportées
+
+### 1. Types API (`web-app/src/shared/types/api.ts`)
+- ✅ Ajout du champ `isHelpingHand: boolean` à l'interface `Action`
+
+### 2. TaskRepository (`web-app/src/data/repositories/taskRepository.ts`)
+- ✅ Import des types `Action` et `CreateActionPayload`
+- ✅ Nouvelle méthode `createAction(payload: CreateActionPayload)` qui appelle l'endpoint `/actions`
+
+### 3. TasksStore (`web-app/src/domain/stores/tasksStore.ts`)
+- ✅ Import des types `Action` et `CreateActionPayload`
+- ✅ Nouvelle méthode `createActionForTask(taskId: number)` qui :
+  - Crée automatiquement le payload avec la date actuelle
+  - Appelle la méthode du repository
+  - Gère les états de loading et d'erreur
+  - Retourne le résultat de l'opération
+
+### 4. TaskCard (`web-app/src/presentation/components/atoms/TaskCard.vue`)
+- ✅ Ajout d'un événement `@click` sur la div principale
+- ✅ Ajout de l'émission de l'événement `click`
+- ✅ Styles CSS pour indiquer que la carte est cliquable :
+  - `cursor: pointer`
+  - Effet `transform: translateY(-2px)` au hover
+
+### 5. TaskList (`web-app/src/presentation/components/molecules/TaskList.vue`)
+- ✅ Propagation de l'événement `click` de TaskCard vers `task-click`
+- ✅ Ajout de l'émission de l'événement `task-click` avec la tâche en paramètre
+
+### 6. GroupDetailView (`web-app/src/presentation/views/GroupDetailView.vue`)
+- ✅ Gestion de l'événement `@task-click` de TaskList
+- ✅ Nouvelle méthode `handleTaskClick(task: Task)` qui :
+  - Appelle `tasksStore.createActionForTask(task.id)`
+  - Gère les cas de succès et d'erreur
+  - Log les résultats (prêt pour des notifications)
+
+## Fonctionnement côté API
+
+L'API, dans le contrôleur `ActionController`, détermine automatiquement la valeur de `isHelpingHand` selon cette logique :
+
+1. Vérifie si l'utilisateur est membre du groupe de la tâche
+2. Recherche un `UserTaskState` pour voir si l'utilisateur `isConcerned` par cette tâche
+3. Définit `isHelpingHand = !isUserConcerned` :
+   - Si l'utilisateur est concerné → `isHelpingHand = false` (sa propre tâche)
+   - Si l'utilisateur n'est pas concerné → `isHelpingHand = true` (coup de main)
+
+## Utilisation
+
+1. L'utilisateur voit les TaskCard dans la vue de détail d'un groupe
+2. Un clic sur une TaskCard déclenche la création d'une action
+3. L'action est automatiquement datée au moment du clic
+4. Le serveur détermine si c'est un "coup de main" ou une tâche personnelle
+5. L'action est sauvegardée avec toutes les relations (task, user, group)
+
+## Gestion des erreurs
+
+- Vérification de l'appartenance au groupe côté API
+- Gestion des erreurs de validation
+- Propagation des erreurs vers l'interface utilisateur
+- États de loading pendant la création
+
+## Points d'extension futurs
+
+- Notifications toast pour le succès/échec
+- Confirmation avant création d'action
+- Historique des actions dans l'interface
+- Statistiques en temps réel

--- a/web-app/src/data/repositories/taskRepository.ts
+++ b/web-app/src/data/repositories/taskRepository.ts
@@ -3,8 +3,10 @@ import type { ApiResult } from '@/shared/types/DataResult'
 import type { 
   Task,
   Tag,
+  Action,
   CreateTaskPayload,
-  CreateTagPayload
+  CreateTagPayload,
+  CreateActionPayload
 } from '@/shared/types/api'
 
 export class TaskRepository {
@@ -56,6 +58,11 @@ export class TaskRepository {
 
   async deleteTag(id: number): Promise<ApiResult<void>> {
     return apiClient.delete<void>(`/tags/${id}`)
+  }
+
+  // Actions
+  async createAction(payload: CreateActionPayload): Promise<ApiResult<{ action: Action }>> {
+    return apiClient.post<{ action: Action }>('/actions', payload)
   }
 }
 

--- a/web-app/src/domain/stores/tasksStore.ts
+++ b/web-app/src/domain/stores/tasksStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { taskRepository } from '@/data/repositories/taskRepository'
-import type { Task, Tag, CreateTaskPayload, CreateTagPayload } from '@/shared/types/api'
+import type { Task, Tag, Action, CreateTaskPayload, CreateTagPayload, CreateActionPayload } from '@/shared/types/api'
 
 export const useTasksStore = defineStore('tasks', () => {
   // State
@@ -210,6 +210,33 @@ export const useTasksStore = defineStore('tasks', () => {
     }
   }
 
+  const createActionForTask = async (taskId: number) => {
+    isLoading.value = true
+    error.value = undefined
+
+    try {
+      const payload: CreateActionPayload = {
+        taskId,
+        date: new Date().toISOString()
+      }
+      
+      const result = await taskRepository.createAction(payload)
+      
+      if (result.isSuccess) {
+        return { success: true, action: result.data.action }
+      } else {
+        error.value = result.message
+        return { success: false, error: result.message }
+      }
+    } catch (err) {
+      const errorMessage = 'Erreur lors de la création de l\'action'
+      error.value = errorMessage
+      return { success: false, error: errorMessage }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
   const setTagFilter = (tag: Tag | null) => {
     selectedTagFilter.value = tag
   }
@@ -257,6 +284,7 @@ export const useTasksStore = defineStore('tasks', () => {
     createTag,
     updateTask,
     deleteTask,
+    createActionForTask,
     setTagFilter,
     clearTagFilter,
     clearCurrentTask,

--- a/web-app/src/presentation/components/atoms/TaskCard.vue
+++ b/web-app/src/presentation/components/atoms/TaskCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="cardClasses">
+  <div :class="cardClasses" @click="$emit('click')" class="task-card-clickable">
     <div class="task-header">
       <div class="task-icon" v-if="task.iconUrl">
         <img :src="task.iconUrl" :alt="task.label" />
@@ -60,6 +60,7 @@ defineEmits<{
   'tag-click': [tag: Tag]
   edit: []
   delete: []
+  click: []
 }>()
 
 const cardClasses = computed(() => [
@@ -92,6 +93,14 @@ const frequencyText = computed(() => {
 .task-card:hover {
   border-color: var(--color-gray-300);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.task-card-clickable {
+  cursor: pointer;
+}
+
+.task-card-clickable:hover {
+  transform: translateY(-2px);
 }
 
 .task-card--compact {

--- a/web-app/src/presentation/components/molecules/TaskList.vue
+++ b/web-app/src/presentation/components/molecules/TaskList.vue
@@ -20,6 +20,7 @@
         @tag-click="$emit('tag-click', $event)"
         @edit="$emit('task-edit', task)"
         @delete="$emit('task-delete', task)"
+        @click="$emit('task-click', task)"
       />
     </div>
     
@@ -55,6 +56,7 @@ defineEmits<{
   'tag-click': [tag: Tag]
   'task-edit': [task: Task]
   'task-delete': [task: Task]
+  'task-click': [task: Task]
 }>()
 
 const filteredTasks = computed(() => {

--- a/web-app/src/presentation/views/GroupDetailView.vue
+++ b/web-app/src/presentation/views/GroupDetailView.vue
@@ -37,6 +37,7 @@
           @tag-click="handleTagClick"
           @task-edit="handleTaskEdit"
           @task-delete="handleTaskDelete"
+          @task-click="handleTaskClick"
         >
           <template #empty-actions>
             <BaseButton
@@ -156,6 +157,18 @@ const handleTaskDelete = async (task: Task) => {
       console.error('Erreur lors de la suppression:', result.error)
       // Optionnel: notification d'erreur
     }
+  }
+}
+
+const handleTaskClick = async (task: Task) => {
+  const result = await tasksStore.createActionForTask(task.id)
+  
+  if (result.success) {
+    console.log('Action créée avec succès:', result.action)
+    // Optionnel: notification de succès
+  } else {
+    console.error('Erreur lors de la création de l\'action:', result.error)
+    // Optionnel: notification d'erreur
   }
 }
 

--- a/web-app/src/shared/types/api.ts
+++ b/web-app/src/shared/types/api.ts
@@ -34,6 +34,7 @@ export interface Task {
 export interface Action {
   id: number
   date: string
+  isHelpingHand: boolean
   task: Task
   user: User
   group: Group


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable action creation on TaskCard click to track user contributions to tasks.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The API automatically determines `isHelpingHand` based on whether the user is 'concerned' by the task, allowing for both personal task completion and 'helping hand' contributions to be logged.